### PR TITLE
Added missing identifiers to STU3 measures/bundles

### DIFF
--- a/fhir3/bundles/EXM161_FHIR3-8.0.0/EXM161_FHIR3-8.0.0-bundle.json
+++ b/fhir3/bundles/EXM161_FHIR3-8.0.0/EXM161_FHIR3-8.0.0-bundle.json
@@ -1140,6 +1140,18 @@
           }
         ],
         "url": "http://hl7.org/fhir/us/cqfmeasures/Measure/measure-EXM161-FHIR3-8.0.0",
+        "identifier": [
+          {
+            "use": "official",
+            "system": "http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms",
+            "value": "161"
+          },
+          {
+            "use": "official",
+            "system": "http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/nqf",
+            "value": "0104"
+          }
+        ],
         "version": "8.0.0",
         "name": "EXM161",
         "title": "Adult Major Depressive Disorder (MDD): Suicide Risk Assessment",

--- a/fhir3/bundles/EXM161_FHIR3-8.0.0/EXM161_FHIR3-8.0.0-files/measure-EXM161_FHIR3-8.0.0.json
+++ b/fhir3/bundles/EXM161_FHIR3-8.0.0/EXM161_FHIR3-8.0.0-files/measure-EXM161_FHIR3-8.0.0.json
@@ -19,6 +19,18 @@
     }
   ],
   "url": "http://hl7.org/fhir/us/cqfmeasures/Measure/measure-EXM161-FHIR3-8.0.0",
+  "identifier": [
+    {
+      "use": "official",
+      "system": "http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms",
+      "value": "161"
+    },
+    {
+      "use": "official",
+      "system": "http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/nqf",
+      "value": "0104"
+    }
+  ],
   "version": "8.0.0",
   "name": "EXM161",
   "title": "Adult Major Depressive Disorder (MDD): Suicide Risk Assessment",

--- a/fhir3/bundles/EXM165_FHIR3-8.5.000/EXM165_FHIR3-8.5.000-bundle.json
+++ b/fhir3/bundles/EXM165_FHIR3-8.5.000/EXM165_FHIR3-8.5.000-bundle.json
@@ -384,6 +384,18 @@
           }
         ],
         "url": "http://hl7.org/fhir/us/cqfmeasures/Measure/measure-EXM165-FHIR3",
+        "identifier": [
+          {
+            "use": "official",
+            "system": "http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms",
+            "value": "165"
+          },
+          {
+            "use": "official",
+            "system": "http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/nqf",
+            "value": "0018"
+          }
+        ],
         "version": "1.0.000",
         "name": "EXM165",
         "title": "Controlling High Blood Pressure",

--- a/fhir3/bundles/EXM165_FHIR3-8.5.000/EXM165_FHIR3-8.5.000-files/measure-EXM165_FHIR3-8.5.000.json
+++ b/fhir3/bundles/EXM165_FHIR3-8.5.000/EXM165_FHIR3-8.5.000-files/measure-EXM165_FHIR3-8.5.000.json
@@ -19,6 +19,18 @@
     }
   ],
   "url": "http://hl7.org/fhir/us/cqfmeasures/Measure/measure-EXM165-FHIR3",
+  "identifier": [
+    {
+      "use": "official",
+      "system": "http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms",
+      "value": "165"
+    },
+    {
+      "use": "official",
+      "system": "http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/nqf",
+      "value": "0018"
+    }
+  ],
   "version": "1.0.000",
   "name": "EXM165",
   "title": "Controlling High Blood Pressure",

--- a/fhir3/bundles/EXM349_FHIR3-2.9.000/EXM349_FHIR3-2.9.000-bundle.json
+++ b/fhir3/bundles/EXM349_FHIR3-2.9.000/EXM349_FHIR3-2.9.000-bundle.json
@@ -3715,6 +3715,13 @@
           }
         ],
         "url": "http://hl7.org/fhir/us/cqfmeasures/Measure/measure-EXM349-FHIR3-2.9.000",
+        "identifier": [
+          {
+            "use": "official",
+            "system": "http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms",
+            "value": "349"
+          }
+        ],
         "version": "2.9.000",
         "name": "EXM349",
         "title": "HIV Screening",

--- a/fhir3/bundles/EXM349_FHIR3-2.9.000/EXM349_FHIR3-2.9.000-files/measure-EXM349_FHIR3-2.9.000.json
+++ b/fhir3/bundles/EXM349_FHIR3-2.9.000/EXM349_FHIR3-2.9.000-files/measure-EXM349_FHIR3-2.9.000.json
@@ -19,6 +19,13 @@
     }
   ],
   "url": "http://hl7.org/fhir/us/cqfmeasures/Measure/measure-EXM349-FHIR3-2.9.000",
+  "identifier": [
+    {
+      "use": "official",
+      "system": "http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms",
+      "value": "349"
+    }
+  ],
   "version": "2.9.000",
   "name": "EXM349",
   "title": "HIV Screening",


### PR DESCRIPTION
Some of the STU3 Measures/Bundles (161, 165, 349) were missing an `identifier`. This PR adds a `cms` identifier and a `nqf` when applicable. Values pulled from [here](https://ecqi.healthit.gov/ep-ec-ecqms)