### PR TITLE
Remove SNAPSHOT status from tooling JAR in fhir401 directory

### DIFF
--- a/fhir401/_refresh.bat
+++ b/fhir401/_refresh.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
-SET tooling_jar=tooling-1.3.0-SNAPSHOT-jar-with-dependencies.jar
+SET tooling_jar=tooling-1.3.0-jar-with-dependencies.jar
 SET input_cache_path=%~dp0input-cache
 SET ig_resource_path=%~dp0input\connectathon.xml
 

--- a/fhir401/_refresh.sh
+++ b/fhir401/_refresh.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #DO NOT EDIT WITH WINDOWS
-tooling_jar=tooling-1.3.0-SNAPSHOT-jar-with-dependencies.jar
+tooling_jar=tooling-1.3.0-jar-with-dependencies.jar
 input_cache_path=./input-cache
 ig_resource_path=./input/connectathon.xml
 

--- a/fhir401/_updateRefreshIG.bat
+++ b/fhir401/_updateRefreshIG.bat
@@ -1,7 +1,7 @@
 @ECHO OFF
 
-SET "dlurl=https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opencds.cqf&a=tooling&v=1.3.0-SNAPSHOT&c=jar-with-dependencies"
-SET tooling_jar=tooling-1.3.0-SNAPSHOT-jar-with-dependencies.jar
+SET "dlurl=https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=org.opencds.cqf&a=tooling&v=1.3.0&c=jar-with-dependencies"
+SET tooling_jar=tooling-1.3.0-jar-with-dependencies.jar
 SET input_cache_path=%~dp0input-cache\
 
 FOR %%x IN ("%CD%") DO SET upper_path=%%~dpx

--- a/fhir401/_updateRefreshIG.sh
+++ b/fhir401/_updateRefreshIG.sh
@@ -2,10 +2,10 @@
 #DO NOT EDIT WITH WINDOWS
 #exit 1
 
-r=snapshots
+r=releases
 g=org.opencds.cqf
 a=tooling
-v=1.3.0-SNAPSHOT
+v=1.3.0
 c=jar-with-dependencies
 
 dlurl='https://oss.sonatype.org/service/local/artifact/maven/redirect?r='${r}'&g='${g}'&a='${a}'&v='${v}'&c='${c}''
@@ -13,7 +13,7 @@ dlurl='https://oss.sonatype.org/service/local/artifact/maven/redirect?r='${r}'&g
 echo ${dlurl}
 
 input_cache_path=./input-cache/
-tooling_jar=tooling-1.3.0-SNAPSHOT-jar-with-dependencies.jar
+tooling_jar=tooling-1.3.0-jar-with-dependencies.jar
 
 set -e
 if ! type "curl" > /dev/null; then


### PR DESCRIPTION
The `1.3.0-SNAPSHOT` version of the tooling JAR no longer exists in oss.sonatype.org. This PR removes the `-SNAPSHOT` designation, so the tooling can be downloaded if not cached.